### PR TITLE
[feat] community 페이지 활발한 사용자 목록 조회 추가

### DIFF
--- a/public/community.html
+++ b/public/community.html
@@ -746,6 +746,25 @@
       </li>
     </template>
 
+    <!-- ActiveUser 템플릿 -->
+    <template id="activeUserItemTemplate">
+      <li class="flex items-center gap-2">
+        <div
+          class="w-8 h-8 rounded-full bg-gray-200 flex-shrink-0 overflow-hidden"
+        >
+          <img
+            src=""
+            alt="프로필"
+            class="w-full h-full object-cover active-user-profile-img"
+          />
+        </div>
+        <div class="flex-1">
+          <p class="text-sm font-medium active-user-nickname"></p>
+          <p class="text-xs text-gray-500 active-user-activity"></p>
+        </div>
+      </li>
+    </template>
+
     <script src="js/community.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 커뮤니티 페이지 사이드바에 "활발한 사용자" 목록 조회 및 표시 기능을 추가했습니다. 백엔드 `/v1/community/active-users` 엔드포인트와 연동하여 최근 활동(기본 14일)을 기준으로 사용자를 조회합니다.

## 📝 작업 상세

- **API 연동 함수 추가 (`fetchActiveUsers`)**:
    - 활발한 사용자 정보를 백엔드로부터 가져오는 `fetchActiveUsers(limit = 5, days = 14)` 함수를 `community.js`에 구현했습니다.
    - 백엔드 컨트롤러(`CommunityController`)의 `@GetMapping("/active-users")`에 정의된 스펙에 따라, 프론트엔드에서는 `API_BASE_URL` 에 `/active-users` 경로를 조합하여 API를 호출합니다.
    - `@RequestParam`으로 정의된 `limit`(기본값 5) 및 `day`(기본값 14, 프론트엔드에서는 `days`로 사용) 파라미터를 백엔드 명세에 맞춰 전달합니다.
    - `fetchApi` 유틸리티 함수를 사용하며, 로딩 및 오류 상황을 고려하여 기본값(빈 배열)을 반환하도록 처리했습니다. 응답 데이터는 `[{userId, nickname, profileImageUrl, postCount, commentCount}, {data2}, ..]` 형태를 기대합니다.
    - ![image](https://github.com/user-attachments/assets/2965d130-4e5e-41e4-9922-b54b8a1480d6)

- **UI 렌더링 함수 추가 (`renderActiveUsers`)**:
    - `fetchActiveUsers`를 통해 받은 사용자 데이터를 기반으로 HTML 요소를 동적으로 생성하여 "활발한 사용자" 목록(`activeUsersContainer`)에 표시하는 `renderActiveUsers` 함수를 구현했습니다.
    - 사용자 프로필 이미지, 닉네임, 활동 내역(예: 게시글 수, 댓글 수)을 표시합니다.
    - `activeUserItemTemplate`을 활용하여 각 사용자 항목을 생성했습니다.
- **로딩 및 빈 상태 처리 로직 추가**:
    - "활발한 사용자" 섹션 데이터 로딩 중 및 데이터가 없을 경우를 위한 플레이스홀더(`loading-active-users`, `empty-active-users`)가 정상적으로 동작하도록 `state.isLoading`, `updateLoadingState`, `showEmptyMessage` 함수를 확장했습니다.
- **초기화 로직에 통합 (`loadActiveUsers`)**:
    - 페이지 로드 시 "활발한 사용자" 목록을 가져오도록 `loadActiveUsers` 함수를 작성하고, 이를 `initializePage` 함수의 `Promise.allSettled` 호출에 포함시켜 다른 데이터와 함께 비동기적으로 로드되도록 했습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] "활발한 사용자" 목록 API (`/v1/community/active-users`) 연동 및 UI 표시 기능 정상 동작 확인 (백엔드 컨트롤러 스펙과 일치)
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- 활발한 사용자 기준은 백엔드 `communityService.getActiveUsers(limit, day)` 로직에 따르며, 프론트엔드는 `day` 파라미터(기본 14일)를 통해 기간을 전달합니다.
- 사이드바 UI의 일관성을 유지하며 기능을 통합했습니다.
- 다음 우선순위 작업으로 CSS 페이지네이션 리팩토링 및 빌드 환경 도입을 고려하고 있습니다.