### PR TITLE
[feat] 401 핸들러를 이용해 헤더 버튼 동적 이벤트 기능 구현

### DIFF
--- a/public/includes/header.html
+++ b/public/includes/header.html
@@ -9,13 +9,13 @@
             <a href="/" id="nav-home" class="text-gray-800 hover:text-primary font-medium">홈</a>
           </li>
           <li>
-            <a href="/matching-type-selection" id="nav-match" class="text-gray-800 hover:text-primary font-medium">매칭</a>
+            <button onclick="navigateTo('/matching-type-selection')" id="nav-match" class="text-gray-800 hover:text-primary font-medium">매칭</button>
           </li>
           <li>
-            <a href="/community" id="nav-community" class="text-gray-800 hover:text-primary font-medium">커뮤니티</a>
+            <button onclick="navigateTo('/community')" id="nav-community" class="text-gray-800 hover:text-primary font-medium">커뮤니티</button>
           </li>
           <li>
-            <a href="/mypage" id="nav-mypage" class="text-gray-800 hover:text-primary font-medium">마이페이지</a>
+            <button id="nav-mypage" class="text-gray-800 hover:text-primary font-medium">마이페이지</button>
           </li>
         </ul>
       </nav>
@@ -41,3 +41,4 @@
     </div>
   </div>
 </header>
+<script src="/js/authHandler.js"></script>


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 헤더 버튼을 401 핸들러 함수를 이용해 트리거 이벤트로 동작 할 수 있게 기능을 추가했습니다

## 📝 작업 상세

- 작업 1: 헤더의 매칭 버튼과 커뮤니티 버튼을 로그인 여부를 판단하여 로그인이 되어 있으면 해당 페이지로 이동하고 없으면 로그인 페이지로 이동 할 수 있게 기능을 추가했습니다
- 작업 2: 마이페이지는 자신의 role을 기준으로 mypage 또는 mypage-mentee 페이지로 이동할 수 있게 이벤트 기능을 추가했습니다

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [x] 문서/주석 최신화

## 📚 기타

- (선택사항)