### PR TITLE
[feat] 마이페이지_멘티 신청한 매칭 더보기 기능 구현 및 코드 분리

### DIFF
--- a/public/js/more-details.js
+++ b/public/js/more-details.js
@@ -40,6 +40,10 @@ function setupPage(type, id) {
     case "my-matches":
       pageTitle.textContent = "신청한 매칭";
       setupFilters(["전체", "진행중", "완료"]);
+      const searchBox = document.getElementById("search-section");
+      if (searchBox) {
+        searchBox.style.display = "none";
+      }
       loadMyMatching(id);
       break;
     case "my-posts":

--- a/public/js/my-matches.js
+++ b/public/js/my-matches.js
@@ -1,141 +1,336 @@
-function loadMatchData(id) {
+// 이미지 오류 처리 함수
+function handleImageError(image) {
+  image.onerror = null; // 무한 루프 방지
+  image.src = "../assets/images/default-profile.png"; // 기본 이미지로 대체
+}
+
+// 현재 사용자 정보 가져오기
+async function getCurrentUserInfo() {
+  try {
+    const response = await fetch("/api/v1/authUser/me", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+
+    if (response.status === 401) {
+      const retry = await handle401Error();
+      if (!retry) {
+        window.location.href = "/login";
+        return null;
+      }
+      // 토큰 갱신 성공, 요청 재시도
+      return await getCurrentUserInfo();
+    }
+
+    if (!response.ok) {
+      console.error("사용자 정보 요청 실패:", response.status);
+      return null;
+    }
+
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("사용자 정보 조회 중 오류 발생:", error);
+    return null;
+  }
+}
+
+// 매칭 데이터 로드 및 렌더링
+async function loadMatchData(id, page = 0) {
   const contentList = document.getElementById("content-list");
+  contentList.innerHTML =
+    '<div class="text-center py-10"><div class="spinner"></div><p class="mt-2 text-gray-500">매칭 정보를 불러오는 중</p></div>';
 
-  // Mock data for matching requests
-  const mockRequests = [
-    {
-      id: 1,
-      mentee: {
-        name: "최서연",
-        image:
-          "https://readdy.ai/api/search-image?query=professional%20asian%20female%20portrait%2C%20neutral%20background%2C%20casual%20style%2C%20high%20quality&width=100&height=100&seq=4&orientation=squarish",
-        date: "2025-04-22",
-      },
-      content: "React와 Node.js로 풀스택 개발 배우기 재능에 관심이 있습니다. 기초부터 차근차근 배우고 싶습니다.",
-      preferredTime: "희망 시간: 주말 오후",
-      status: "pending",
-    },
-    {
-      id: 2,
-      mentee: {
-        name: "박준호",
-        image:
-          "https://readdy.ai/api/search-image?query=professional%20asian%20male%20portrait%2C%20neutral%20background%2C%20glasses%2C%20friendly%20look%2C%20high%20quality&width=100&height=100&seq=3&orientation=squarish",
-        date: "2025-04-20",
-      },
-      content:
-        "주니어 개발자를 위한 코드 리뷰 재능에 관심이 있습니다. 현재 진행 중인 프로젝트에 대한 코드 리뷰를 받고 싶습니다.",
-      preferredTime: "희망 시간: 평일 저녁",
-      status: "pending",
-    },
-    {
-      id: 3,
-      mentee: {
-        name: "김민지",
-        image:
-          "https://readdy.ai/api/search-image?query=professional%20asian%20female%20portrait%2C%20neutral%20background%2C%20young%20professional%2C%20high%20quality&width=100&height=100&seq=8&orientation=squarish",
-        date: "2025-04-18",
-      },
-      content:
-        "React 컴포넌트 설계와 상태 관리에 대해 배우고 싶습니다. 실무에서 사용하는 패턴과 구조에 대해 알고 싶습니다.",
-      preferredTime: "희망 시간: 주말 오전",
-      status: "accepted",
-    },
-  ];
+  // 세션 스토리지에서 닉네임 가져오기 (한 번만 호출)
+  const sessionNickname = sessionStorage.getItem("nickname");
 
-  // 매칭 리스트 렌더링 기존 코드
-  mockRequests.forEach((match) => {
-    const matchesElement = document.createElement("div");
-    matchesElement.className = "border border-gray-200 rounded-lg p-4 hover:shadow-md transition";
-    matchesElement.innerHTML = `
-        <div class="flex items-start gap-3">
-          <div class="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0 overflow-hidden">
-            <img src="${match.mentee.image}" alt="프로필" class="w-full h-full object-cover">
+  if (!sessionNickname) {
+    contentList.innerHTML = `
+        <div class="text-center py-10">
+          <div class="w-12 h-12 mx-auto mb-3 text-red-500">
+            <i class="ri-error-warning-line text-3xl"></i>
           </div>
-          <div class="flex-1">
-            <div class="flex justify-between items-start">
-              <div>
-                <h3 class="font-medium">${match.mentee.name}</h3>
-                <p class="text-xs text-gray-500">${match.mentee.date} 요청</p>
-              </div>
-              <div class="flex items-center gap-2">
-                ${
-                  match.status === "pending"
-                    ? `
-                <span class="bg-green-100 text-green-700 text-xs px-2 py-1 rounded-full">진행중</span>
-              `
-                    : match.status === "accepted"
-                    ? `
-                <span class="bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded-full">완료</span>
-              `
-                    : ``
-                }
-              </div>
-            </div>
-            <p class="text-sm text-gray-600 mt-2">${match.content}</p>
-             <div class="flex items-center justify-between mt-3">
-              <div class="flex items-center text-sm text-gray-500">
-                <div class="w-4 h-4 flex items-center justify-center mr-1">
-                    <i class="ri-time-line"></i>
-                </div>
-                <span> ${match.preferredTime}</span>
-                </div>
-                <div class="flex items-center gap-2">
-                <button class="text-primary text-sm font-medium hover:underline">
-                    연락하기
-                </button>
-                <button class="text-gray-500 hover:text-red-500 text-sm">
-                    종료하기
-                </button>
-              </div>
-          </div>
+          <p class="text-gray-700 font-medium">사용자 정보를 찾을 수 없습니다.</p>
+          <p class="text-gray-500 mt-1">다시 접근해주세요.</p>
         </div>
       `;
+    return;
+  }
 
-    // 수락/거절 버튼에 이벤트 리스너 추가
-    const acceptButton = matchesElement.querySelector(".bg-primary");
-    const rejectButton = matchesElement.querySelector(".bg-gray-200");
+  // 현재 사용자 정보 가져오기
+  const currentUser = await getCurrentUserInfo();
+  const isOwner = currentUser && currentUser.status === 200 && currentUser.code === "SUCCESS";
 
-    if (acceptButton) {
-      acceptButton.addEventListener("click", function () {
-        handleMatchAccept(match.id);
+  // 세션의 닉네임과 API에서 반환된 닉네임 비교
+  const isAuthorized = isOwner && currentUser.data && currentUser.data.nickname === sessionNickname;
+
+  // 매칭 목록 API 호출 함수
+  async function fetchMyMatches(pageNumber = 0) {
+    const apiUrl = `/api/v1/users/${sessionNickname}/activity/more-details?type=my-matches&page=${pageNumber}&size=10`;
+    const response = await fetch(apiUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+
+    if (response.status === 401) {
+      const retry = await handle401Error();
+      if (!retry) {
+        window.location.href = "/login";
+        return;
+      }
+      // 토큰 갱신 성공, 요청 재시도
+      return await fetchMyMatches(pageNumber);
+    }
+
+    if (!response.ok) {
+      throw new Error("API 요청 실패: " + response.status);
+    }
+
+    return response.json();
+  }
+
+  try {
+    const result = await fetchMyMatches(page);
+
+    if (result.status === 200 && result.code === "SUCCESS" && result.data && result.data.content) {
+      // 데이터가 있는 경우 렌더링
+      renderMatches(result.data.content, isAuthorized);
+
+      // 페이지네이션 정보가 있으면 페이지네이션 렌더링
+      if (result.data.page) {
+        renderPagination(result.data.page);
+      }
+    } else {
+      console.error("API 응답 형식이 예상과 다릅니다:", result);
+      showNoMatchesMessage();
+    }
+  } catch (error) {
+    console.error("매칭 데이터 로드 중 오류 발생:", error);
+    contentList.innerHTML = `
+        <div class="text-center py-10">
+          <div class="w-12 h-12 mx-auto mb-3 text-red-500">
+            <i class="ri-error-warning-line text-3xl"></i>
+          </div>
+          <p class="text-gray-700 font-medium">데이터를 불러올 수 없습니다.</p>
+          <p class="text-gray-500 mt-1">${error.message || "나중에 다시 시도해주세요."}</p>
+        </div>
+      `;
+  }
+}
+
+// 페이지네이션 렌더링 함수
+function renderPagination(pageInfo) {
+  const paginationContainer = document.querySelector(".flex.justify-center.mt-6");
+  if (!paginationContainer) return;
+
+  // 페이지네이션 컨테이너 초기화
+  paginationContainer.innerHTML = '<nav class="inline-flex rounded-md shadow-sm"></nav>';
+
+  const navElement = paginationContainer.querySelector("nav");
+
+  // 이전 페이지 버튼
+  const prevButton = document.createElement("a");
+  prevButton.href = "#";
+  prevButton.className = "px-3 py-2 border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 rounded-l-md";
+  prevButton.textContent = "이전";
+
+  if (pageInfo.number > 0) {
+    prevButton.addEventListener("click", function (e) {
+      e.preventDefault();
+      loadMatchData(null, pageInfo.number - 1);
+    });
+  } else {
+    prevButton.classList.add("opacity-50", "cursor-not-allowed");
+  }
+
+  navElement.appendChild(prevButton);
+
+  // 페이지 번호 버튼
+  const startPage = Math.max(0, pageInfo.number - 2);
+  const endPage = Math.min(pageInfo.totalPages - 1, pageInfo.number + 2);
+
+  for (let i = startPage; i <= endPage; i++) {
+    const pageButton = document.createElement("a");
+    pageButton.href = "#";
+    pageButton.textContent = i + 1;
+
+    if (i === pageInfo.number) {
+      pageButton.className = "px-3 py-2 border-t border-b border-gray-300 bg-primary text-white";
+    } else {
+      pageButton.className = "px-3 py-2 border-t border-b border-gray-300 bg-white text-gray-500 hover:bg-gray-50";
+      pageButton.addEventListener("click", function (e) {
+        e.preventDefault();
+        loadMatchData(null, i);
       });
     }
 
-    if (rejectButton) {
-      rejectButton.addEventListener("click", function () {
-        handleMatchReject(match.id);
-      });
-    }
+    navElement.appendChild(pageButton);
+  }
 
+  // 다음 페이지 버튼
+  const nextButton = document.createElement("a");
+  nextButton.href = "#";
+  nextButton.className = "px-3 py-2 border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 rounded-r-md";
+  nextButton.textContent = "다음";
+
+  if (pageInfo.number < pageInfo.totalPages - 1) {
+    nextButton.addEventListener("click", function (e) {
+      e.preventDefault();
+      loadMatchData(null, pageInfo.number + 1);
+    });
+  } else {
+    nextButton.classList.add("opacity-50", "cursor-not-allowed");
+  }
+
+  navElement.appendChild(nextButton);
+}
+
+// 매칭 데이터 렌더링
+function renderMatches(matchesData, isAuthorized) {
+  const contentList = document.getElementById("content-list");
+  contentList.innerHTML = "";
+
+  // 데이터가 없는 경우 처리
+  if (!matchesData || matchesData.length === 0) {
+    showNoMatchesMessage();
+    return;
+  }
+
+  // 매칭 데이터 렌더링
+  matchesData.forEach((match, index) => {
+    const mentorData = match.mentor;
+    const createdAt = new Date(match.createdAt);
+    const formattedDate = `${createdAt.getFullYear()}-${String(createdAt.getMonth() + 1).padStart(2, "0")}-${String(
+      createdAt.getDate()
+    ).padStart(2, "0")}`;
+
+    // 고유 ID 생성
+    const contactBtnId = `contact-btn-${index}-${match.sessionId}`;
+    const terminateBtnId = `terminate-btn-${index}-${match.sessionId}`;
+
+    // 진행 중 여부 확인
+    const isInProgress = match.status === "IN_PROGRESS";
+
+    const matchesElement = document.createElement("div");
+    matchesElement.className = "border border-gray-200 rounded-lg p-4 hover:shadow-md transition";
+
+    // 버튼 영역 HTML - 삼항 연산자로 간결하게 작성
+    const buttonsHtml = !isInProgress
+      ? `<span class="text-gray-400 text-sm">완료된 매칭</span>`
+      : isAuthorized
+      ? `<div class="flex items-center gap-2">
+                 <button id="${contactBtnId}" class="text-primary text-sm font-medium hover:underline" data-id="${mentorData.mentorId}" data-session="${match.sessionId}">
+                   연락하기
+                 </button>
+                 <button id="${terminateBtnId}" class="text-gray-500 hover:text-red-500 text-sm" data-id="${mentorData.mentorId}" data-session="${match.sessionId}">
+                   종료하기
+                 </button>
+               </div>`
+      : `<div></div>`;
+
+    matchesElement.innerHTML = `
+             <div class="flex items-start gap-3">
+               <div class="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0 overflow-hidden">
+                 <img src="${mentorData.profileImageUrl || "../assets/images/default-profile.png"}" 
+                      alt="프로필" 
+                      class="w-full h-full object-cover"
+                      onerror="handleImageError(this)" />
+               </div>
+               <div class="flex-1">
+                 <div class="flex justify-between items-start">
+                   <div>
+                     <h3 class="font-medium">${mentorData.nickname || "이름 없음"}</h3>
+                     <p class="text-xs text-gray-500">${formattedDate} 요청</p>
+                   </div>
+                   <div class="flex items-center gap-2">
+                     <span class="${
+                       isInProgress ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-700"
+                     } text-xs px-2 py-1 rounded-full">
+                       ${isInProgress ? "진행중" : "완료"}
+                     </span>
+                   </div>
+                 </div>
+                 <p class="text-primary text-sm font-medium mt-1">${mentorData.interest || ""}</p>
+                 <p class="text-sm text-gray-600 mt-2">${mentorData.introduction || "소개 정보가 없습니다."}</p>
+                 <div class="flex items-center justify-between mt-3">
+                   <div class="flex items-center text-sm text-gray-500">
+                     <div class="w-4 h-4 flex items-center justify-center mr-1">
+                       <i class="ri-time-line"></i>
+                     </div>
+                     <span>${mentorData.activityTime || "시간 정보 없음"}</span>
+                   </div>
+                   ${buttonsHtml}
+                 </div>
+               </div>
+             </div>
+           `;
+
+    // DOM에 요소 추가
     contentList.appendChild(matchesElement);
+
+    // 권한이 있고 상태가 IN_PROGRESS인 경우에만 이벤트 리스너 추가
+    if (isAuthorized && isInProgress) {
+      // 요소가 DOM에 추가된 후 이벤트 리스너 연결
+      const contactButton = document.getElementById(contactBtnId);
+      if (contactButton) {
+        contactButton.addEventListener("click", function () {
+          handleMatchContact(this.getAttribute("data-id"), mentorData.contactLink);
+        });
+      }
+
+      // 종료하기 버튼에 이벤트 리스너 추가
+      const terminateButton = document.getElementById(terminateBtnId);
+      if (terminateButton) {
+        terminateButton.addEventListener("click", function () {
+          handleMatchTerminate(this.getAttribute("data-id"), this.getAttribute("data-session"));
+        });
+      }
+    }
   });
 }
 
-/**
- * 매칭 수락 처리
- * @param {number} matchId - 매칭 ID
- */
-function handleMatchAccept(matchId) {
-  console.log(`매칭 ID ${matchId} 수락 처리`);
-
-  // API 호출 및 처리 로직
-  alert(`매칭이 수락되었습니다. (ID: ${matchId})`);
-
-  // 페이지 새로고침 또는 상태 업데이트
-  loadMyMatching();
+// 매칭 없음 메시지 표시
+function showNoMatchesMessage() {
+  const contentList = document.getElementById("content-list");
+  contentList.innerHTML = `
+          <div class="text-center py-10">
+            <div class="w-16 h-16 mx-auto mb-3 text-gray-300">
+              <i class="ri-file-list-3-line text-4xl"></i>
+            </div>
+            <p class="text-gray-700 font-medium">신청한 매칭이 없습니다.</p>
+            <p class="text-gray-500 mt-1">재능 기부 페이지에서 관심있는 멘토를 찾아보세요!</p>
+            <a href="/matching-type-selection" class="inline-block mt-4 px-4 py-2 bg-primary text-white rounded-lg hover:bg-indigo-600">
+              재능 기부 찾기
+            </a>
+          </div>
+        `;
 }
 
-/**
- * 매칭 거절 처리
- * @param {number} matchId - 매칭 ID
- */
-function handleMatchReject(matchId) {
-  console.log(`매칭 ID ${matchId} 거절 처리`);
+// 매칭 연락하기 처리
+function handleMatchContact(mentorId, contactLink) {
+  console.log(`멘토 ID ${mentorId} 연락하기`);
 
-  // API 호출 및 처리 로직
-  alert(`매칭이 거절되었습니다. (ID: ${matchId})`);
+  if (contactLink) {
+    // 연락 링크가 있는 경우 해당 링크로 이동
+    window.open(contactLink, "_blank");
+  } else {
+    // 연락 링크가 없는 경우 알림 표시
+    alert("연락처 정보가 없습니다. 관리자에게 문의해주세요.");
+  }
+}
 
-  // 페이지 새로고침 또는 상태 업데이트
-  loadMyMatching();
+// 매칭 종료하기 처리
+function handleMatchTerminate(mentorId, sessionId) {
+  console.log(`멘토 ID ${mentorId}, 세션 ID ${sessionId} 매칭 종료하기`);
+
+  if (confirm("정말 이 매칭을 종료하시겠습니까?")) {
+    // 종료 처리 로직 구현
+    // ...
+  }
 }

--- a/public/more-details.html
+++ b/public/more-details.html
@@ -45,7 +45,7 @@
               </button>
               <!-- 동적으로 필터 버튼이 추가될 수 있음 -->
             </div>
-            <div class="relative">
+            <div class="relative" id="search-section">
               <input
                 type="text"
                 id="search-input"
@@ -63,30 +63,9 @@
         <div id="content-list" class="space-y-4">
           <!-- 여기에 동적으로 컨텐츠가 추가됨 -->
         </div>
-
         <!-- 페이지네이션 -->
         <div class="flex justify-center mt-6">
-          <nav class="inline-flex rounded-md shadow-sm">
-            <a href="#" class="px-3 py-2 border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 rounded-l-md"
-              >이전</a
-            >
-            <a href="#" class="px-3 py-2 border-t border-b border-gray-300 bg-primary text-white">1</a>
-            <a href="#" class="px-3 py-2 border-t border-b border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-              >2</a
-            >
-            <a href="#" class="px-3 py-2 border-t border-b border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-              >3</a
-            >
-            <a href="#" class="px-3 py-2 border-t border-b border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-              >4</a
-            >
-            <a href="#" class="px-3 py-2 border-t border-b border-gray-300 bg-white text-gray-500 hover:bg-gray-50"
-              >5</a
-            >
-            <a href="#" class="px-3 py-2 border border-gray-300 bg-white text-gray-500 hover:bg-gray-50 rounded-r-md"
-              >다음</a
-            >
-          </nav>
+          <!-- 여기에 동적으로 페이지네이션이 생성됩니다 -->
         </div>
       </div>
     </main>


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- 마이페이지의 '활동 내역' 탭에 **사용자가 신청한 매칭 목록을 조회**하는 기능을 구현했습니다.
- 신청한 매칭 목록 관련 로직 (`loadMatchData`, 렌더링, 액션 핸들러 등)을 `public/js/my-matches.js` 파일로 **분리하여 코드의 응집도를 높였습니다**.
- 신청한 매칭 목록 페이지에 **페이지네이션 기능을 추가**하여 대량의 데이터도 효율적으로 표시할 수 있게 했습니다.
- 매칭 상태에 따라 **조건부 버튼 표시 및 연락하기/종료하기 기능을 구현**했습니다.
- 프로필 이미지 로딩 실패 시 **기본 이미지가 표시**되도록 처리했습니다.

## 📝 작업 상세

### 신청한 매칭(My Matches) 관련 코드 파일 분리 및 페이지 구조 개선

- **`public/js/match.js` 파일의 `loadMatchingRequests` 함수 및 관련 매칭 목록 렌더링 코드를 삭제**했습니다.
- **새로운 파일 `public/js/my-matches.js`를 생성**하여 신청한 매칭 목록을 로드하고 렌더링하는 로직을 옮겼습니다.
- `public/js/more-details.js` 파일에서 `my-matches` 타입으로 페이지 설정 시, **`public/js/my-matches.js` 스크립트를 동적으로 로드**하도록 변경했습니다.
- `more-details.html` 페이지에서 `type=my-matches`로 접근 시, **페이지 제목이 '신청한 매칭'으로 표시**되도록 설정했습니다.
- '신청한 매칭' 페이지에서 **검색 섹션(`search-section`)이 표시되지 않도록** 처리했습니다.
- `more-details.html` 파일의 **페이지네이션 HTML 구조를 동적 생성을 위해 단순화**했습니다.

### 신청한 매칭 더보기 기능 구현 (데이터 로드, 렌더링, 페이지네이션, 액션)

- **API 연동:** `/api/v1/users/{nickname}/activity/more-details?type=my-matches...` 엔드포인트를 호출하여 현재 로그인한 사용자가 신청한 매칭 목록 데이터를 가져오도록 `public/js/my-matches.js`에 `fetchMyMatches` 함수를 구현했습니다.
- **사용자 및 권한 확인:** `getCurrentUserInfo` 함수를 통해 현재 로그인 사용자 정보를 가져와 API 호출 권한 및 매칭 목록 관리 권한이 있는지 확인하는 로직을 추가했습니다. API 호출 시 401 응답에 대한 토큰 갱신 처리 로직도 포함되었습니다.
- **데이터 렌더링:** 가져온 매칭 데이터를 `renderMatches` 함수를 통해 `content-list` 영역에 동적으로 표시합니다. 각 매칭 항목에는 멘토 닉네임, 신청일, 상태, 소개, 활동 시간 등이 포함됩니다.
- **상태별 버튼 표시 및 액션 처리:**
    - 매칭 상태가 `IN_PROGRESS`인 경우, **'연락하기' 및 '종료하기' 버튼이 표시**됩니다.
    - **'연락하기' 버튼 클릭 시 멘토의 연락 링크(contactLink)로 새 창을 열거나 링크가 없을 경우 알림**을 표시합니다 (`handleMatchContact`).
    - **'종료하기' 버튼 클릭 시 확인 창을 띄우고 매칭 종료 처리 로직을 수행**하도록 했습니다 (`handleMatchTerminate`).
    - 완료된 매칭에는 버튼 대신 '완료된 매칭' 텍스트가 표시됩니다.
- **페이지네이션 구현:** API 응답에 포함된 페이지 정보를 바탕으로 `renderPagination` 함수가 페이지네이션 버튼(`이전`, 페이지 번호, `다음`)을 동적으로 생성하고, **클릭 시 해당 페이지의 매칭 목록을 다시 로드**하도록 구현했습니다.
- **데이터 없음 처리:** 신청한 매칭이 없을 경우 `showNoMatchesMessage` 함수를 호출하여 **"신청한 매칭이 없습니다." 메시지와 재능 기부 페이지로 이동하는 링크를 표시**합니다.
- **이미지 오류 처리:** `handleImageError` 함수를 추가하여 프로필 이미지 로딩 중 오류 발생 시 **`../assets/images/default-profile.png` 기본 이미지가 표시**되도록 처리했습니다.

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과 (로컬 환경 테스트)
- [x] 문서/주석 최신화 (코드 내 주요 함수 주석 추가)

## 📚 기타

