### PR TITLE
[Feat] 댓글 토스트 상단 이동 & 관련 게시물 섹션 hidden 처리

### DIFF
--- a/public/community-detail.html
+++ b/public/community-detail.html
@@ -198,7 +198,7 @@
         </div>
 
         <!-- 관련 게시글 -->
-        <div class="bg-white rounded-lg shadow-sm p-4">
+        <div id="related-posts-section" class="bg-white rounded-lg shadow-sm p-4 hidden">
           <h3 class="font-medium mb-3">관련 게시글</h3>
           <ul class="space-y-3">
             <!-- 관련 게시글 목록 -->

--- a/public/js/community-detail.js
+++ b/public/js/community-detail.js
@@ -1351,20 +1351,25 @@ function showToast(message, type = 'info') {
       icon = '<i class="ri-information-line mr-2"></i>';
   }
 
-  toast.className = `fixed top-4 right-4 z-50 ${bgColor} ${textColor} px-4 py-3 rounded-md shadow-md flex items-center transition-all duration-300 opacity-0 transform translate-y-[-20px]`;
+  toast.className =
+      `fixed top-4 left-1/2 -translate-x-1/2 z-50
+     ${bgColor} ${textColor}
+     px-4 py-3 rounded-md shadow-md flex items-center
+     transition-all duration-300
+     opacity-0 -translate-y-5`;
+
   toast.innerHTML = `${icon}${message}`;
+  document.body.prepend(toast);
 
-  document.body.appendChild(toast);
+  // 등장 애니메이션
+  requestAnimationFrame(() => {
+    toast.classList.remove('opacity-0', '-translate-y-5');
+  });
 
-  // 애니메이션 적용
+  // 3초 뒤 사라지기
   setTimeout(() => {
-    toast.classList.remove('opacity-0', 'translate-y-[-20px]');
-  }, 10);
-
-  // 일정 시간 후 제거
-  setTimeout(() => {
-    toast.classList.add('opacity-0', 'translate-y-[-20px]');
-    setTimeout(() => toast.remove(), 300);
+    toast.classList.add('opacity-0', '-translate-y-5');
+    setTimeout(() => toast.remove(), 300);   // transition 끝난 뒤 제거
   }, 3000);
 }
 // 좋아요 토글 함수


### PR DESCRIPTION
## ✨ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

---

## 🛠️ 작업 요약
댓글 작성 후 표시되는 토스트를 화면 상단 중앙에 고정 표시하고, 관련 게시물 섹션을 기본 숨김 처리했습니다.

---

## 📝 작업 상세
- 작업 1: `community-detail.js`
  - `showToast()` 함수의 `className`에 `top-4 left-1/2 -translate-x-1/2` 적용 및 공백 보정
  - `document.body.prepend(toast)` 로 토스트를 맨 앞에 출력
  - 등장·퇴장 애니메이션 클래스 수정
- 작업 2: `community-detail.html`
  - 관련 게시물 `<div>`에 `hidden` 클래스 추가 (추후 피드백에 따라 활성화 예정)

---

## ✅ 체크리스트
- [x] 코드 점검 완료
- [x] 토스트 정상 표시(위치·색상·애니메이션) 확인
- [x] 관련 게시물 섹션 숨김 처리 확인
- [x] 문서/주석 최신화

---

## 📚 기타
- “관련 게시물” 기능은 베타 피드백에 따라 재활성화할 예정입니다.

![image](https://github.com/user-attachments/assets/2c7905ef-8193-4d03-a45b-7660fc8bafbe)