### PR TITLE
[Feat] 멘토 전용 재능나눔 카테고리 표시

### DIFF
--- a/public/js/newPost.js
+++ b/public/js/newPost.js
@@ -328,4 +328,15 @@ document.addEventListener("DOMContentLoaded", function () {
             return "";
         }
     });
+
+    // ❶ 로컬 스토리지에서 userType 읽기 (include-and-authHandler.js 에서 세팅됨)
+    const userType = localStorage.getItem("userType"); // 'mentor', 'mentee' 등
+
+    // ❷ 멘토면 재능나눔 카테고리 보이기
+    if (userType === "mentor") {
+        const talentItem = document.getElementById("talentCategoryItem");
+        if (talentItem) {
+            talentItem.classList.remove("hidden");
+        }
+    }
 });

--- a/public/newPost.html
+++ b/public/newPost.html
@@ -145,8 +145,9 @@
                   자유게시판
                 </li>
                 <li
+                        id="talentCategoryItem"
                         class="px-4 py-2 hover:bg-gray-100 cursor-pointer text-sm hidden"
-                        data-value="free"
+                        data-value="talent"
                 >
                   재능나눔
                 </li>


### PR DESCRIPTION
## ✨ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

---

## 🛠️ 작업 요약
- 멘토(ROLE_MENTOR) 사용자에게만 ‘재능나눔’ 카테고리 표시

---

## 📝 작업 상세
- 작업 1: `newPost.js` & HTML  
  - “재능나눔” `<li>`에 `id="talentCategoryItem"`, `data-value="talent"` 설정  
  - `DOMContentLoaded` 시 `localStorage.getItem('userType') === 'mentor'` 인 경우에만 `.hidden` 제거

---

## ✅ 체크리스트
- [x] ROLE_MENTOR 계정으로 로그인했을 때만 “재능나눔” 옵션 노출 확인
- [x] 다른 계정(멘티/비로그인)에서는 숨김 확인

---

## 📚 기타
- “재능나눔” 기능은 멘토 전용이며, 향후 권한 변경 시 `userType` 검증 로직을 백엔드에도 추가할 예정입니다.
![image](https://github.com/user-attachments/assets/373555e7-b8ba-4767-8700-cfbaa4654c44)

![image](https://github.com/user-attachments/assets/fd2a6821-c17e-48bd-bc4a-fec15cc182d6)

