### PR TITLE
[feat] 커뮤니티 상세: AI 답변 표시 및 작성자 조회 로직 개선

### DIFF
--- a/public/css/community.css
+++ b/public/css/community.css
@@ -220,3 +220,21 @@ input:checked + .switch-slider:before {
   font-weight: 500; /* font-medium */
 }
 /* ====== 태그 버튼 스타일 끝 ====== */
+#aiAnswerContent {
+  overflow: hidden; /* 이 부분이 중요합니다. max-height와 함께 사용되어 내용을 접습니다. */
+  transition: max-height 0.35s ease-in-out, opacity 0.3s ease-in-out; /* 부드러운 애니메이션 */
+  line-height: 1.6;
+  opacity: 1; /* 확장 시 확실히 보이도록 */
+}
+
+#aiAnswerContent.collapsed {
+  /* max-height는 JS에서 설정합니다. */
+  opacity: 0.7; /* 접혔을 때 약간 흐리게 하여 더 볼 내용이 있음을 암시 (선택적) */
+}
+
+#aiAnswerContent.expanding, #aiAnswerContent.collapsing {
+  /* 애니메이션 중에는 opacity를 조절하여 자연스럽게 */
+  opacity: 0.5;
+}
+
+


### PR DESCRIPTION
## ✨ PR 종류

-   [x] 기능 추가
-   [ ] 버그 수정
-   [x] 리팩토링 (작성자 조회 로직 변경)
-   [ ] 문서 수정
-   [ ] 기타

## 🛠️ 작업 요약

-   커뮤니티 상세 페이지 내 '질문' 유형 게시글에 대해 AI가 생성한 답변을 표시하는 기능을 추가했습니다.
-   게시글 작성자의 상세 정보를 조회하는 방식을 기존 `userId` 기반에서 `nickname` 기반으로 변경하여 API 호출 경로 및 관련 로직을 수정했습니다.

## 📝 작업 상세

-   **AI 답변 기능 추가 (`community-detail.js`):**
    -   `loadAiAnswer(postId)` 함수를 신규 추가하여, `/api/v1/community/ai/:postId` API를 통해 AI 답변을 비동기적으로 조회합니다.
    -   `loadPostDetail` 함수 내에서 게시글의 `category`가 'QUESTION'일 경우, `loadAiAnswer` 함수를 호출하여 AI 답변을 가져와 화면의 `aiAnswerSection` 영역에 표시합니다.
    -   AI 답변 내용은 `aiAnswerContent` 요소의 `innerHTML`을 통해 업데이트되며, 응답이 없거나 오류 발생 시 해당 섹션은 숨김 처리됩니다.
    -   *참고: AI 답변이 긴 경우를 대비하여 향후 펼치기/접기 UI 적용을 고려하고 있습니다 (관련 사용자 코멘트: "ai댓글 길어서 뭔가 누르면 펼쳐지도록 해야할것같은데").*
    -   *참고: "ai 댓글 복구중.." 코멘트를 통해 기존 기능의 복원 또는 개선 작업의 일환임을 확인했습니다.*

-   **작성자 상세 정보 조회 로직 변경 (`community-detail.js`):**
    -   `WorkspaceAuthorDetails` 함수의 파라미터를 `userId`에서 `nickname`으로 변경하고, 내부 API 호출 경로를 `/api/v1/user/:userId/profile`에서 `/api/v1/users/:nickname`으로 수정했습니다.
    -   이에 따라 `loadPostDetail` 함수에서 `WorkspaceAuthorDetails` 호출 시 `post.userId` 대신 `post.nickname`을 전달하도록 변경했습니다.
    -   이 변경은 사용자 친화적인 URL 및 API 식별자 사용을 목적으로 합니다 (관련 사용자 코멘트: "활발한 사용자 url 수정, id -> nickname").
    -   `WorkspaceAuthorDetails` 내 `console.warn` 메시지의 파라미터 관련 내용을 'ID'에서 '닉네임'으로 명확히 하는 것이 좋습니다 (현재: "작성자 ID가 제공되지 않았습니다").

## ✅ 체크리스트

-   [x] 코드 점검 완료 (자체 리뷰)
-   [x] 기능 정상 동작 테스트 완료
-   [ ] 관련 API 명세 또는 문서 업데이트 
-   [x] 주석 추가 및 코드 가독성 개선

## 📚 기타

-   AI 답변을 `innerHTML`로 삽입하는 부분은 서버로부터 받는 데이터가 신뢰할 수 있고, XSS 공격으로부터 안전하게 처리되었다는 가정하에 구현되었습니다. 만약 서버 측에서 HTML 이스케이프 처리가 되어있지 않다면, 클라이언트 측에서의 추가적인 처리가 필요할 수 있습니다.
-   이번 변경으로 게시글 상세 페이지의 정보 제공 방식이 개선되었으며, 특히 질문 유형 게시글에 대한 활용도가 높아질 것으로 기대됩니다.
