### PR TITLE
[fix] 게시글 이미지 업로드 및 표시 기능 개선

### DIFF
--- a/public/js/community-detail.js
+++ b/public/js/community-detail.js
@@ -337,15 +337,66 @@ function renderPostDetail(post) {
   if (elements.likeCount) elements.likeCount.textContent = post.likeCount || 0;
   if (elements.commentCount) elements.commentCount.textContent = post.commentCount || 0;
 
-  // 이미지 표시
-  if (elements.postImages && post.imageUrls && post.imageUrls.length > 0) {
-    elements.postImages.innerHTML = post.imageUrls.map(url => `
-      <div class="mb-3">
-        <img src="${url}" alt="게시글 이미지" class="rounded-md max-w-full">
-      </div>
-    `).join('');
-  } else if (elements.postImages) {
-    elements.postImages.style.display = 'none';
+// 이미지 표시 부분 수정
+  if (elements.postImages) {
+    // 이미지 URL 존재 여부 로깅
+    console.log('게시글 이미지 URL 목록:', post.imageUrls);
+
+    // 게시글 내용에 이미지 태그가 있는지 확인
+    const contentHasImages = elements.postContentBody &&
+        elements.postContentBody.innerHTML &&
+        elements.postContentBody.innerHTML.includes('<img');
+
+    console.log('게시글 내용에 이미지 태그 존재 여부:', contentHasImages);
+
+    // 게시글 내용에 이미지가 없고, imageUrls가 있는 경우에만 별도로 이미지 표시
+    if (!contentHasImages && post.imageUrls && post.imageUrls.length > 0) {
+      // 배열인 경우
+      if (Array.isArray(post.imageUrls)) {
+        elements.postImages.innerHTML = post.imageUrls.map(url => `
+                <div class="mb-3">
+                    <img src="${url}" alt="게시글 이미지" class="rounded-md max-w-full" onerror="this.onerror=null; this.src='./assets/images/image-error.png'; console.error('이미지 로드 실패:', this.src);">
+                </div>
+            `).join('');
+      }
+      // 문자열인 경우 (여러 URL이 콤마로 구분된 형태일 수 있음)
+      else if (typeof post.imageUrls === 'string') {
+        // 콤마로 구분된 경우 배열로 변환
+        const urlArray = post.imageUrls.includes(',')
+            ? post.imageUrls.split(',').map(url => url.trim())
+            : [post.imageUrls.trim()];
+
+        elements.postImages.innerHTML = urlArray.map(url => `
+                <div class="mb-3">
+                    <img src="${url}" alt="게시글 이미지" class="rounded-md max-w-full" onerror="this.onerror=null; this.src='./assets/images/image-error.png'; console.error('이미지 로드 실패:', this.src);">
+                </div>
+            `).join('');
+      }
+
+      // 이미지 컨테이너 표시
+      elements.postImages.style.display = 'block';
+    } else {
+      // 이미지가 없거나 게시글 내용에 이미지가 이미 포함된 경우 숨김
+      elements.postImages.style.display = 'none';
+    }
+
+    // 게시글 내용의 모든 이미지 태그에 오류 처리 및 스타일 추가
+    if (elements.postContentBody) {
+      const contentImages = elements.postContentBody.querySelectorAll('img');
+      if (contentImages.length > 0) {
+        contentImages.forEach(img => {
+          // 이미지 로드 오류 처리
+          img.onerror = function() {
+            this.onerror = null;
+            this.src = './assets/images/image-error.png';
+            console.error('내용 내 이미지 로드 실패:', this.src);
+          };
+
+          // 이미지 클래스 추가
+          img.classList.add('rounded-md', 'max-w-full', 'my-4');
+        });
+      }
+    }
   }
 
   // 태그 표시


### PR DESCRIPTION
## ✨ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약
- 게시글 작성 시 이미지 업로드 후 표시되지 않거나 중복 표시되는 버그 수정

## 📝 작업 상세
- 작업 1: `community-detail.js`에서 이미지 중복 표시 문제 해결 
  - 게시글 내용에 이미지 태그가 이미 포함된 경우 별도 이미지 섹션 미표시 처리
  - 이미지 로드 오류 처리 추가

- 작업 2: `newPost.js`에서 이미지 업로드 및 처리 로직 개선
  - 이미지 업로드 응답 데이터 구조 검증 로직 추가
  - 오류 발생 시 사용자 피드백 개선
  - 로깅 기능 강화로 디버깅 용이성 제공

- 작업 3: 이미지 URL 처리 방식 개선
  - 다양한 형태(배열, 문자열)의 이미지 URL 데이터 지원
  - 게시글 내용과 별도 이미지 URL 간의 일관성 유지

## ✅ 체크리스트
- [x] 코드 점검 완료
- [x] 테스트 통과 (다양한 이미지 업로드 및 표시 테스트)
- [x] 문서/주석 최신화

## 📚 기타
- 해당 버그는 이미지가 Supabase 저장소에는 정상적으로 업로드되었으나 프론트엔드에서 표시되지 않거나 중복 표시되는 문제였습니다.
- 게시글 내용 업데이트와 이미지 URL 목록 간의 관계를 명확히 하여 일관된 이미지 표시 방식을 구현했습니다.
- 이전에는 이미지 오류 시 사용자에게 충분한 피드백이 제공되지 않았으나, 이제는 오류 발생 시 명확한 알림이 표시됩니다.