### PR TITLE
[refactor] my-interests.js 동적 로딩으로 변경 - 필터 충돌 방지

### DIFF
--- a/public/js/more-details.js
+++ b/public/js/more-details.js
@@ -97,9 +97,11 @@ function setupPage(type, id) {
       break;
     case "my-interests":
       pageTitle.textContent = "관심 목록";
-      // 검색창은 숨김 처리 (선택)
       if (filterSection) filterSection.classList.remove("hidden");
-      // ✅ 여기서 필요한 필터 버튼은 my-interests.js가 생성함
+
+      const script = document.createElement("script");
+      script.src = "js/my-interests.js";
+      document.body.appendChild(script);
       break;
     default:
       pageTitle.textContent = "상세 정보";


### PR DESCRIPTION
## ✨ PR 종류

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- my-interests.js를 동적 로딩 방식으로 변경하여 타 페이지 필터 충돌 방지

## 📝 작업 상세

- 작업 1: more-details.js에서 type === 'my-interests' 조건일 때만 my-interests.js를 script 태그로 동적으로 로드
- 작업 2: 정적 <script> 로딩 방식 제거하여, my-matches 등 다른 타입의 필터 영역이 덮어써지는 문제 방지

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [ ] 문서/주석 최신화

## 📚 기타
