### PR TITLE
[feat] '연락하기' 버튼 상태 기반 동작 및 스타일/툴팁 개선 (미리보기+더보기 공통 반영)

### DIFF
--- a/public/css/mypage.css
+++ b/public/css/mypage.css
@@ -166,3 +166,37 @@ input:checked + .toggle-slider:before {
 /* ====== End Fix (more-details.html) ====== */
 
 /* ====== 페이징 스타일 끝 ====== */
+
+/* 툴팁용 스타일 */
+.custom-tooltip {
+  position: absolute;
+  top: -40px;
+  right: 0;
+  background-color: white;
+  border: 1px solid #888;
+  color: #333;
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  z-index: 1000;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+
+.custom-tooltip.fade-out {
+  opacity: 0;
+}
+
+.tooltip-icon {
+  color: #f97316;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.tooltip-text {
+  white-space: nowrap;
+}

--- a/public/js/mypage.js
+++ b/public/js/mypage.js
@@ -269,7 +269,8 @@ async function populateProfileData() {
               el.innerHTML = html;
             })
         );
-        // ✅ include가 끝난 후에만 실행하도록 여기에 탭/렌더링 JS를 배치해야 해!
+
+        // include가 끝난 후에만 실행하도록 여기에 탭/렌더링 JS를 배치
         initMyPage();
       });
 
@@ -903,39 +904,99 @@ async function populateProfileData() {
 
 
 // ✅ [추가] 진행 중인 매칭 섹션 렌더링 함수
-  function renderOngoingMatchingSection(matchings) {
-    const container = document.getElementById("ongoing-matching-list");
-    if (!container || !matchings || matchings.length === 0) return;
+//   function renderOngoingMatchingSection(matchings) {
+//     const container = document.getElementById("ongoing-matching-list");
+//     if (!container || !matchings || matchings.length === 0) return;
+//
+//     container.innerHTML = '';
+//
+//     matchings.forEach(match => {
+//       // 기본값 처리
+//       const profileImage = match.menteeProfileImageUrl || '/images/default-profile.png';
+//       const nickname = match.menteeNickname || '닉네임 없음';
+//       const matchingDate = match.matchingDate?.split("T")[0] || '날짜 없음';
+//       const category = match.category || '카테고리 없음';
+//       const tag = match.tag || '-';
+//       const description = match.description || '';
+//       const contactLink = match.contactLink || '#';
+//       const status = match.status || '진행중';
+//
+//       // 상태 pill 색상 지정
+//       const statusColorClass = status === "진행중"
+//           ? "bg-yellow-100 text-yellow-700"
+//           : "bg-green-100 text-green-700";
+//
+//       const card = document.createElement("div");
+//       card.className = "border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition";
+//
+//       card.innerHTML = `
+//       <div class="flex items-start gap-3">
+//         <!-- 프로필 이미지 -->
+//         <div class="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0 overflow-hidden">
+//           <img src="${profileImage}" alt="프로필" class="w-full h-full object-cover">
+//         </div>
+//
+//         <!-- 본문 -->
+//         <div class="flex-1">
+//           <div class="flex justify-between items-start mb-1">
+//             <div>
+//               <p class="text-sm font-medium text-gray-800">${nickname}</p>
+//               <p class="text-xs text-gray-500">${matchingDate} 매칭</p>
+//             </div>
+//             <span class="text-xs ${statusColorClass} px-2 py-1 rounded-full whitespace-nowrap font-medium">
+//               ${status}
+//             </span>
+//           </div>
+//
+//           <div class="text-xs text-purple-600 font-semibold mb-1">${category}</div>
+//           <p class="text-sm text-gray-700 line-clamp-2">${description}</p>
+//
+//           <div class="mt-2 flex justify-end">
+//             <a href="${contactLink || '#'}"
+//                target="_blank"
+//                class="text-sm text-blue-800 font-extrabold hover:underline open-chat-link"
+//                data-haslink="${!!contactLink}">
+//                연락하기
+//             </a>
+//           </div>
+//         </div>
+//       </div>
+//     `;
+//
+//       container.appendChild(card);
+//     });
+//   }
+function renderOngoingMatchingSection(matchings) {
+  const container = document.getElementById("ongoing-matching-list");
+  if (!container || !matchings || matchings.length === 0) return;
 
-    container.innerHTML = '';
+  container.innerHTML = '';
 
-    matchings.forEach(match => {
-      // 기본값 처리
-      const profileImage = match.menteeProfileImageUrl || '/images/default-profile.png';
-      const nickname = match.menteeNickname || '닉네임 없음';
-      const matchingDate = match.matchingDate?.split("T")[0] || '날짜 없음';
-      const category = match.category || '카테고리 없음';
-      const tag = match.tag || '-';
-      const description = match.description || '';
-      const contactLink = match.contactLink || '#';
-      const status = match.status || '진행중';
+  matchings.forEach(match => {
+    // 기본값 처리
+    const profileImage = match.menteeProfileImageUrl || '/images/default-profile.png';
+    const nickname = match.menteeNickname || '닉네임 없음';
+    const matchingDate = match.matchingDate?.split("T")[0] || '날짜 없음';
+    const category = match.category || '카테고리 없음';
+    const tag = match.tag || '-';
+    const description = match.description || '';
+    const contactLink = match.contactLink;  // 빈 문자열 또는 null일 수도 있음
+    const status = match.status || '진행중';
 
-      // 상태 pill 색상 지정
-      const statusColorClass = status === "진행중"
-          ? "bg-yellow-100 text-yellow-700"
-          : "bg-green-100 text-green-700";
+    // 상태 pill 색상 지정
+    const statusColorClass = status === "진행중"
+        ? "bg-green-100 text-green-700"
+        : "bg-gray-100 text-gray-700";
 
-      const card = document.createElement("div");
-      card.className = "border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition";
+    const card = document.createElement("div");
+    card.className = "border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition";
 
-      card.innerHTML = `
+    // 카드 내부 HTML 렌더링
+    card.innerHTML = `
       <div class="flex items-start gap-3">
-        <!-- 프로필 이미지 -->
         <div class="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0 overflow-hidden">
           <img src="${profileImage}" alt="프로필" class="w-full h-full object-cover">
         </div>
-
-        <!-- 본문 -->
         <div class="flex-1">
           <div class="flex justify-between items-start mb-1">
             <div>
@@ -946,19 +1007,67 @@ async function populateProfileData() {
               ${status}
             </span>
           </div>
-
           <div class="text-xs text-purple-600 font-semibold mb-1">${category}</div>
           <p class="text-sm text-gray-700 line-clamp-2">${description}</p>
-
-          <div class="mt-2 flex justify-end">
-            <a href="${contactLink}" target="_blank" class="text-sm text-blue-800 font-extrabold hover:underline">연락하기</a>
-          </div>
         </div>
       </div>
     `;
 
-      container.appendChild(card);
-    });
-  }
+// 🔹 연락하기 링크 추가
+    const linkWrapper = document.createElement("div");
+    linkWrapper.className = "mt-2 flex justify-end";
+    linkWrapper.style.position = "relative";
+
+    const link = document.createElement("a");
+    link.href = contactLink || "#";
+    link.target = "_blank";
+    link.className = "text-sm font-extrabold open-chat-link";
+    link.textContent = "연락하기";
+
+    if (status === "완료") {
+      link.classList.add("text-gray-400", "cursor-not-allowed");
+      link.setAttribute("aria-disabled", "true");
+      // ✅ hover용 title 제거
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+
+        // 이미 툴팁이 있다면 제거
+        const existingTooltip = linkWrapper.querySelector('.custom-tooltip');
+        if (existingTooltip) existingTooltip.remove();
+
+        const tooltip = document.createElement("div");
+        tooltip.className = "custom-tooltip";
+        tooltip.innerHTML = `
+      <span class="tooltip-icon">❗</span>
+      <span class="tooltip-text">매칭이 완료된 멘티입니다.</span>
+    `;
+        linkWrapper.appendChild(tooltip);
+
+        setTimeout(() => {
+          tooltip.classList.add("fade-out");
+        }, 2000);
+
+        setTimeout(() => {
+          tooltip.remove();
+        }, 2500);
+      });
+    } else {
+      link.classList.add("text-blue-800", "hover:underline");
+
+      // ✅ 진행중인데 연락처가 없는 경우 alert
+      link.addEventListener("click", (e) => {
+        if (!contactLink || contactLink.trim() === "") {
+          e.preventDefault();
+          alert("이 유저는 오픈채팅 링크를 등록하지 않았습니다.");
+        }
+      });
+    }
+
+    linkWrapper.appendChild(link);
+    card.querySelector(".flex-1").appendChild(linkWrapper);
+
+    container.appendChild(card);
+  });
+}
 
 

--- a/public/js/ongoing.js
+++ b/public/js/ongoing.js
@@ -36,8 +36,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             const imageUrl = item.menteeProfileImageUrl || '/img/default-profile.png';
             const nickname = item.menteeNickname || '닉네임 없음';
             const date = item.matchingDate ? new Date(item.matchingDate).toLocaleDateString() : '-';
-            const statusText = item.status === 'IN_PROGRESS' ? '진행중' : '완료';
-            const statusClass = item.status === 'IN_PROGRESS' ? 'bg-green-500' : 'bg-gray-400';
+            const normalizedStatus = (item.status || '').trim().toLowerCase();
+            const isCompleted = normalizedStatus === '완료' || normalizedStatus === 'completed';
+            const statusText = isCompleted ? '완료' : '진행중';
+            const statusClass = isCompleted
+                ? 'bg-gray-600 text-gray-100'
+                : 'bg-green-500 text-green-100';
+
+            const statusPill = `
+              <span class="text-xs ${statusClass} px-2 py-1 rounded-full whitespace-nowrap font-medium">
+                ${statusText}
+              </span>
+            `;
+
             const contactLink = item.contactLink ?? null;
 
             const tags = (item.tag || '').split(',').filter(Boolean).map(tag =>
@@ -73,14 +84,28 @@ document.addEventListener('DOMContentLoaded', async () => {
     </div>
 
     <!-- 연락하기 버튼 -->
-    <div class="flex-shrink-0 ml-4 mt-1">
-      <a href="${contactLink || '#'}"
-         target="_blank"
-         class="text-sm text-primary font-bold hover:underline open-chat-link whitespace-nowrap"
-         data-haslink="${!!contactLink}">
-         연락하기
-      </a>
+    <div class="flex-shrink-0 ml-4 mt-1 relative">
+        ${isCompleted
+                ? `
+<a href="#"
+  class="text-sm font-bold text-gray-400 cursor-not-allowed whitespace-nowrap"
+  aria-disabled="true"
+  onclick="event.preventDefault(); showCompletedTooltip(this);">
+  연락하기
+</a>
+`
+                : `
+<a href="${contactLink || '#'}"
+  target="_blank"
+  class="text-sm font-bold text-blue-800 hover:underline open-chat-link whitespace-nowrap"
+  data-haslink="${!!contactLink}">
+  연락하기
+</a>
+`
+            }
+
     </div>
+
   </div>
 `;
 
@@ -103,3 +128,20 @@ document.addEventListener('click', function (e) {
         }
     }
 });
+
+function showCompletedTooltip(el) {
+    const existing = el.parentElement.querySelector('.custom-tooltip');
+    if (existing) existing.remove();
+
+    const tooltip = document.createElement('div');
+    tooltip.className = 'custom-tooltip';
+    tooltip.innerHTML = `
+    <span class="tooltip-icon">❗</span>
+    <span class="tooltip-text">매칭이 완료된 멘티입니다.</span>
+  `;
+
+    el.parentElement.appendChild(tooltip);
+
+    setTimeout(() => tooltip.classList.add('fade-out'), 2000);
+    setTimeout(() => tooltip.remove(), 2500);
+}


### PR DESCRIPTION
## ✨ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🛠️ 작업 요약

- `연락하기` 버튼 동작 및 스타일을 진행 상태에 따라 다르게 처리
- 미리보기/더보기 모두 적용 (기능 통일)
- 전역 이벤트 제거 및 개별 이벤트 처리 방식 개선

## 📝 작업 상세

- 진행중일 경우:
    - 연락처 있으면 링크 이동
    - 없으면 alert 안내 출력

- 완료 상태일 경우:
    - 버튼 비활성화 (`cursor-not-allowed`)
    - 클릭 시 툴팁 형태로 “매칭이 완료된 멘티입니다.” 메시지 출력 (fade-out 효과 포함)

- 진행 상태 pill:
    - `진행중` → 초록 배경 + 흰 글자
    - `완료` → 회색 배경 + 흰 글자

- 전역 `.addEventListener` 방식 제거, 버튼마다 이벤트 부착
- 위 로직을 마이페이지 및 더보기 화면에 공통 적용

## ✅ 체크리스트

- [x] 코드 점검 완료
- [x] 테스트 통과
- [ ] 문서/주석 최신화

## 📚 기타
